### PR TITLE
Use supplied ReadFun.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Curious about what we're building?  Try out these posts:
 * [Programming Models, Part 3: Ad Counter, Part 1](http://christophermeiklejohn.com/derflow/erlang/2014/11/16/ad-counter-derflow.html)
 * [Programming Models, Part 4: One Week in Louvain-la-Neuve](http://christophermeiklejohn.com/erlang/lasp/2014/12/21/lasp.html)
 
+We also have a workshop paper:
+
+* [Lasp: a language for distributed, eventually consistent computations with CRDTs](http://dl.acm.org/citation.cfm?id=2745954)
+
 To build:
 
 * `make devrel`: Build six development releases.

--- a/rebar.config
+++ b/rebar.config
@@ -18,6 +18,7 @@
 {cover_enabled, true}.
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.
 {edoc_opts, [{preprocess, true}]}.
+{erl_first_files, "src/lasp_program.erl"}.
 
 {plugin_dir, ".rebar_plugins"}.
 {plugins, [rebar_test_plugin]}.

--- a/src/lasp_vnode.erl
+++ b/src/lasp_vnode.erl
@@ -82,7 +82,7 @@
 
 -define(READ, fun(_Id, _Threshold, _Store) ->
                   %% Beware of cycles in the gen_server calls!
-                  [{IndexNode, _Type}] = ?APP:preflist(?N, _Id, lasp),
+                  [{IndexNode, _Type}|_] = ?APP:preflist(?N, _Id, lasp),
 
                   case IndexNode of
                       {Partition, Node} ->
@@ -373,8 +373,8 @@ handle_command({declare, {ReqId, _}, Id, Type}, _From,
     {reply, {ok, ReqId, Id}, State};
 
 handle_command({bind_to, {ReqId, _}, Id, DVId}, _From,
-               State=#state{store=Store}) ->
-    ok = ?CORE:bind_to(Id, DVId, Store, ?BIND),
+               State=#state{partition=Partition, node=Node, store=Store}) ->
+    ok = ?CORE:bind_to(Id, DVId, Store, ?BIND, ?READ),
     {reply, {ok, ReqId, ok}, State};
 
 handle_command({bind, {ReqId, _}, Id, Value}, _From,


### PR DESCRIPTION
Use the supplied ReadFun to ensure that we know how to properly route read requests when doing program rewriting for read_any, etc.